### PR TITLE
Enhance 404 page logging and remove unused TypeScript definitions

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -2,7 +2,14 @@
 import Layout from "../layouts/BlogPost.astro";
 import { SITE_TITLE } from "../consts";
 import { t } from "../i18n";
+import { Fragment } from "astro/compiler-runtime";
 
+console.log("--- 404 PAGE TRIGGERED ---");
+console.log("Pathname:", Astro.url.pathname);
+console.log(
+  "Headers:",
+  JSON.stringify(Object.fromEntries(Astro.request.headers.entries()))
+);
 // Detectar el idioma basado en la URL o headers
 const pathname = Astro.url.pathname;
 const langFromPath = pathname.startsWith("/es/")

--- a/src/types/astro-env.d.ts
+++ b/src/types/astro-env.d.ts
@@ -1,5 +1,0 @@
-declare module "*.astro" {
-  import type { AstroComponentFactory } from "astro";
-  const component: AstroComponentFactory;
-  export default component;
-}


### PR DESCRIPTION
- Added console logging to the 404 page for better debugging, including pathname and request headers.
- Deleted the unused TypeScript definitions file for Astro components to clean up the codebase.