### PR TITLE
Docker permissions to execute dist on CD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,11 @@ RUN pnpm install --prod --frozen-lockfile
 FROM runner AS final
 
 # Copy runtime deps and built app
-COPY --from=prod-deps /app/node_modules ./node_modules
-COPY --from=build /app/dist ./dist
+COPY --chown=nodeuser:nodeuser --from=prod-deps /app/node_modules ./node_modules
+COPY --chown=nodeuser:nodeuser --from=build /app/dist ./dist
 # Copy source assets needed by astro:assets runtime and public files
-COPY --from=build /app/public ./public
-COPY --from=build /app/src/assets ./src/assets
+COPY --chown=nodeuser:nodeuser --from=build /app/public ./public
+COPY --chown=nodeuser:nodeuser --from=build /app/src/assets ./src/assets
 
 # Run as non-root for security
 RUN useradd -m -u 1001 nodeuser


### PR DESCRIPTION
1.Your Dockerfile creates a non-privileged user called nodeuser to run the application (which is an excellent security practice).

2.However, the files that are copied to the container (dist, node_modules, etc.) belong to the root user.

3.When the process starts as **nodeuser**, it is very likely that it will not have permission to read the server files it needs to render the pages, including the 404 page.

## The solution:
We need to tell Docker to assign ownership of the files to **nodeuser** when copying them. This is done with the flag `--chown=nodeuser:nodeuser`.