### PR TITLE
feat: add production Dockerfile for Cloud Run

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,0 +1,35 @@
+# Production image for erades.com
+
+FROM node:22-slim AS builder
+
+# Enable Corepack and install pnpm at fixed version
+ARG PNPM_VERSION=10.15.0
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+
+WORKDIR /app
+
+# Install dependencies based on lockfile
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+# Copy source code and build the site
+COPY . .
+RUN pnpm run build
+
+# --- Runtime image ---
+FROM node:22-slim AS runner
+ENV NODE_ENV=production
+WORKDIR /app
+
+# Copy built output
+COPY --from=builder /app/dist ./dist
+
+# Ensure non-root permissions
+RUN chown -R node:node /app
+USER node
+
+# Cloud Run injects PORT. Default to 8080 and expose it.
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["node", "./dist/server/entry.mjs"]


### PR DESCRIPTION
## Summary
- create production-ready Dockerfile that builds Astro app and serves on PORT 8080

## Testing
- `pnpm lint`
- `pnpm test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68b37782a66c83299d2ff5516a485dc4