### PR TITLE
Replace automerge workflow with comprehensive CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,8 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - name: Install Playwright Browsers
-        uses: microsoft/playwright-github-action@v1
+      - name: Install Playwright browsers and dependencies
+        run: npx playwright install --with-deps
       - run: pnpm test:e2e
 
   Visual-Regression-Tests:


### PR DESCRIPTION
## Summary
- fix E2E test step by installing Playwright browsers and dependencies with `npx playwright install --with-deps`
- ensure CI workflow runs on pushes to `master`

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:unit`
- `pnpm build`
- `npx playwright install --with-deps` *(failed: Domain forbidden downloading binaries)*
- `pnpm test:e2e` *(failed: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68b38fd3d6548329bc0b45baf1f29ccc