### PR TITLE
Make deployment platform-agnostic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,8 @@ COPY --from=builder /app/dist ./dist
 RUN chown -R node:node /app
 USER node
 
-# Cloud Run injects PORT. Default to 8080 and expose it.
+# Platform injects PORT (Render, etc.). Default to 8080.
 ENV PORT=8080
 EXPOSE 8080
 
 CMD ["node", "./dist/server/entry.mjs"]
-

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -64,7 +64,7 @@ export const onRequest: MiddlewareHandler = async (context, next) => {
   const url = new URL(context.request.url);
   const pathname = url.pathname;
 
-  // Configuración base para Cloud Run
+  // Cabeceras de seguridad y caché (agnóstico del proveedor)
   response.headers.set("X-Content-Type-Options", "nosniff");
   response.headers.set("X-Frame-Options", "DENY");
   response.headers.set("X-XSS-Protection", "1; mode=block");


### PR DESCRIPTION
Remove Cloud Run specific references in comments and configuration, making the application deployable to any platform that injects PORT environment variable (Render, Railway, etc.)